### PR TITLE
bridge-web: fixed logo alignment in Footer

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -14,7 +14,7 @@ export function Footer(props: FooterProps) {
 
   return (
     <footer className="py-20 px-28 text-f-primary">
-      <div className="pt-10 flex justify-between border-t border-neutral/40">
+      <div className="pt-10 flex justify-between items-center border-t border-neutral/40">
         <BridgeLogo
           theme={selectedTheme}
           onClick={() => navigate('buildnet/index')}


### PR DESCRIPTION
We are updating `BridgeLogo` alignment in `Footer`.