### PR TITLE
bridge-web: fix text for mint/redeem

### DIFF
--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -30,7 +30,7 @@
     "loading-box": {
       "title-bridge": "Processing bridge transfer...",
       "title-redeem": "Processing redeem...",
-      "subtitle": "(It can take up to 2 minutes...)",
+      "subtitle": "(It can take up to 2 minutes)",
       "approve": "approval",
       "bridge": "bridge",
       "redeem": "redeem",
@@ -43,14 +43,15 @@
       "inconsistent-not-found": "burn (inconsistent or not found)",
       "massa-faucet-link": "https://discord.gg/FS2NVAum",
       "sepolia-faucet-link": "https://sepoliafaucet.com/",
-      "redeemed": "Successfully redeemed:",
-      "minted": "Successfully minted:",
+      "redeemed": "You have successfully redeemed:",
+      "minted": "You have successfully minted:",
       "from-to": "from {from} to {to}",
       "check": "Check the balance in your Metamask wallet.",
       "add-tokens-message": "You might need to manually add the token to your wallet.",
-      "add-tokens": "instructions",
+      "add-tokens": "Instructions",
       "error": "Something went wrong. Drop us a message at:",
-      "massa-support": "support@bridge.massa.net"
+      "massa-support": "support@bridge.massa.net",
+      "success": "Success!"
     },
     "input": {
       "placeholder": {

--- a/src/pages/Index/Loading.tsx
+++ b/src/pages/Index/Loading.tsx
@@ -52,7 +52,9 @@ export function LoadingBox(props: ILoadingBoxProps) {
         >
           {loadingState(loading.box, 'lg')}
           <p className="mas-subtitle pt-6">
-            {massaToEvm
+            {IS_BOX_SUCCESS
+              ? Intl.t('index.loading-box.success')
+              : massaToEvm
               ? Intl.t('index.loading-box.title-redeem')
               : Intl.t('index.loading-box.title-bridge')}
           </p>
@@ -131,7 +133,7 @@ function Ran(props: ILoadingBoxProps) {
           ? Intl.t('index.loading-box.redeemed')
           : Intl.t('index.loading-box.minted')}
         <div className="mas-subtitle p-2">
-          {amount} [{token?.symbol}]
+          {amount} {token?.symbol}
         </div>
         {Intl.t('index.loading-box.from-to', {
           from: massaToEvm ? massa : sepolia,


### PR DESCRIPTION
We are updating text for min/redeem in the `BridgePopUp`.