### PR TITLE
update bridge event timeout

### DIFF
--- a/src/custom/bridge/massa-utils.ts
+++ b/src/custom/bridge/massa-utils.ts
@@ -4,7 +4,7 @@ import delay from 'delay';
 import { CONTRACT_ADDRESS } from '@/const';
 import { safeJsonParse } from '@/utils/utils';
 
-const WAIT_STATUS_TIMEOUT = 120_000;
+const WAIT_STATUS_TIMEOUT = 300_000;
 const STATUS_POLL_INTERVAL_MS = 1000;
 
 async function getOperationStatus(

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -47,7 +47,7 @@
       "title-bridge-error": "Bridge failed",
       "title-redeem": "Processing redeem...",
       "title-redeem-error": "Redeem failed",
-      "subtitle": "(it can take up to 2 minutes)",
+      "subtitle": "(it can take up to 5 minutes)",
       "approve": "Approval",
       "bridge": "Bridge",
       "redeem": "Redeem",


### PR DESCRIPTION
We are missing some bridge events because it takes more than 2 minutes to be fired.

We are then updating the timeout to be able to read that fired event. This MR adds that.