### PR TITLE
Rework Failed Operation Wording

### DIFF
--- a/src/components/IconsCheck/ErrorCheck/ErrorCheck.tsx
+++ b/src/components/IconsCheck/ErrorCheck/ErrorCheck.tsx
@@ -1,4 +1,4 @@
-import { RxCross2 } from 'react-icons/rx';
+import { FiAlertTriangle } from 'react-icons/fi';
 
 export function ErrorCheck({ size = 'sm' }: { size?: 'sm' | 'md' | 'lg' }) {
   const isSmall = size === 'sm';
@@ -11,9 +11,9 @@ export function ErrorCheck({ size = 'sm' }: { size?: 'sm' | 'md' | 'lg' }) {
 
   return (
     <div
-      className={`${sizeClass} rounded-full bg-s-error/30 flex justify-center items-center border-none`}
+      className={`${sizeClass} rounded-full bg-s-warning/30 flex justify-center items-center border-none p-1`}
     >
-      <RxCross2 className="text-s-error w-full h-full p-1" />
+      <FiAlertTriangle className="text-s-warning w-full h-full p-1" />
     </div>
   );
 }

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -44,9 +44,9 @@
     },
     "loading-box": {
       "title-bridge": "Processing bridge...",
-      "title-bridge-error": "Bridge failed",
+      "title-bridge-error": "Bridge transfer not yet finalized",
       "title-redeem": "Processing redeem...",
-      "title-redeem-error": "Redeem failed",
+      "title-redeem-error": "Redeem transfer not yet finalized",
       "subtitle": "(it can take up to 5 minutes)",
       "approve": "Approval",
       "bridge": "Bridge",
@@ -64,8 +64,10 @@
       "check": "Check the balance in your {name} wallet.",
       "add-tokens-message": "You might need to add the token manually to see its balance.",
       "instructions": "Instructions",
-      "error-something": "Something went wrong!",
-      "error-drop": "Please, drop us a message at:",
+      "error-description": "Transfer delay due to high traffic.",
+      "error-expect": "Expect tokens in your {wallet}",
+      "error-time": "within one hour.",
+      "error-contact": "If not received, contact us at:",
       "success": "Success!"
     },
     "input": {

--- a/src/pages/Index/Loading.tsx
+++ b/src/pages/Index/Loading.tsx
@@ -37,7 +37,7 @@ export function LoadingBox(props: ILoadingBoxProps) {
         className={`z-10 absolute flex-none max-w-2xl w-full h-[870px] blur-md`}
       />
       <div
-        className="absolute z-10 p-10 max-w-sm w-full min-h-96 border border-tertiary rounded-2xl
+        className="absolute z-10 p-10 pb-14 max-w-sm w-full min-h-96 border border-tertiary rounded-2xl
               bg-secondary/50 backdrop-blur-lg text-f-primary"
       >
         <div className="flex justify-end pb-8">
@@ -51,10 +51,10 @@ export function LoadingBox(props: ILoadingBoxProps) {
           </button>
         </div>
         <div
-          className={`relative flex flex-col items-center justify-start pb-10`}
+          className={`relative flex flex-col items-center justify-start mb-10`}
         >
-          {loadingState(loading.box, 'lg')}
-          <p className="mas-subtitle pt-6">
+          <div className="mb-4">{loadingState(loading.box, 'lg')}</div>
+          <p className="mas-subtitle pt-6 text-center">
             {IS_BOX_SUCCESS
               ? Intl.t('index.loading-box.success')
               : HAS_SERVER_ERROR
@@ -74,7 +74,7 @@ export function LoadingBox(props: ILoadingBoxProps) {
         {IS_BOX_SUCCESS ? (
           <Ran {...props} />
         ) : HAS_SERVER_ERROR ? (
-          <BridgeError />
+          <BridgeError {...props} />
         ) : massaToEvm ? (
           <RunningMassaEVM {...props} />
         ) : (
@@ -173,11 +173,21 @@ function Ran(props: ILoadingBoxProps) {
   );
 }
 
-export function BridgeError() {
+export function BridgeError(props: ILoadingBoxProps) {
+  const { massaToEvm } = props;
   return (
     <div className="text-center mas-body2">
-      <p> {Intl.t('index.loading-box.error-something')}</p>
-      <p> {Intl.t('index.loading-box.error-drop')}</p>
+      <p> {Intl.t('index.loading-box.error-description')}</p>
+      <p>
+        {Intl.t('index.loading-box.error-expect', {
+          wallet: massaToEvm ? 'Metamask' : 'Massa Wallet',
+        })}
+      </p>
+      <strong className="mas-menu">
+        {Intl.t('index.loading-box.error-time')}
+      </strong>
+      <br />
+      <p> {Intl.t('index.loading-box.error-contact')}</p>
       <br />
       <u>
         <a href="mailto:support.bridge@massa.net" target="_blank">


### PR DESCRIPTION
This Pr changes the wording of the bridge failed  + displayed icon

<img width="542" alt="Screenshot 2023-09-27 at 14 16 04" src="https://github.com/massalabs/bridge-web/assets/90157528/ff0d03b3-730e-4741-8c6c-517a111572b3">

<img width="692" alt="Screenshot 2023-09-27 at 14 16 54" src="https://github.com/massalabs/bridge-web/assets/90157528/b5b32483-8f47-451d-99ad-830fc6d6685d">
