### PR TITLE
fix link to massa download under connect wallet

### DIFF
--- a/src/components/ConnectWalletPopup/CardVariations/MassaError.tsx
+++ b/src/components/ConnectWalletPopup/CardVariations/MassaError.tsx
@@ -3,7 +3,7 @@ import { FetchingStatus } from '@/pages/Index/Loading';
 import { useAccountStore } from '@/store/store';
 import {
   MASSA_STATION_URL,
-  linkToInstall,
+  MASSA_STATION_INSTALL,
   linkToCreateAccount,
 } from '@/utils/const';
 
@@ -17,7 +17,7 @@ interface IErrorObject {
 
 const ErrorObject: IErrorObject = {
   errorMassaStation: {
-    url: linkToInstall,
+    url: MASSA_STATION_INSTALL,
     content: Intl.t('connect-wallet.station-connect-error.error-station'),
   },
   errorAccount: {

--- a/src/components/ConnectWalletPopup/CardVariations/RessourceSidePanel.tsx
+++ b/src/components/ConnectWalletPopup/CardVariations/RessourceSidePanel.tsx
@@ -3,7 +3,7 @@ import { useAccount } from 'wagmi';
 
 import Intl from '@/i18n/i18n';
 import { useAccountStore } from '@/store/store';
-import { MASSA_STATION_URL } from '@/utils/const';
+import { MASSA_STATION_INSTALL, MASSA_STATION_URL } from '@/utils/const';
 
 function SepoliaInstructions() {
   return (
@@ -23,19 +23,37 @@ function SepoliaInstructions() {
   );
 }
 
-function MassaStationInstructions() {
+function MassaStationDownload() {
   return (
     <div className="flex flex-col justify-center items-center gap-5">
-      <Tag type="success" content="Create a Massa Wallet" />
+      <Tag type="success" content={Intl.t('connect-wallet.download-massa')} />
       <p className="text-center mas-menu-default w-60">
         {Intl.t('connect-wallet.ressource-sidepanel.download-massa-station')}
       </p>
       <a
         className="mas-menu-underline"
-        href="https://station.massa.net"
+        href={MASSA_STATION_INSTALL}
         target="_blank"
       >
         {Intl.t('general.download')}
+      </a>
+    </div>
+  );
+}
+
+function MassaStationInstructions() {
+  return (
+    <div className="flex flex-col justify-center items-center gap-5">
+      <Tag type="success" content={Intl.t('connect-wallet.create-wallet')} />
+      <p className="text-center mas-menu-default w-60">
+        {Intl.t('connect-wallet.ressource-sidepanel.download-massa-station')}
+      </p>
+      <a
+        className="mas-menu-underline"
+        href={MASSA_STATION_URL}
+        target="_blank"
+      >
+        {Intl.t('general.click-here')}
       </a>
     </div>
   );
@@ -61,33 +79,9 @@ export function RessourceSidePanel() {
     >
       {isBothNotConnected ? (
         <>
-          <div className="flex flex-col justify-center items-center gap-5">
-            <Tag type="info" content="Add Sepolia testnet" />
-            <p className="text-center mas-menu-default w-60">
-              {Intl.t('connect-wallet.ressource-sidepanel.add-sepolia')}
-            </p>
-            <a
-              className="mas-menu-underline"
-              href="https://support.metamask.io/hc/en-us/articles/13946422437147-How-to-view-testnets-in-MetaMask"
-              target="_blank"
-            >
-              {Intl.t('general.click-here')}
-            </a>
-          </div>
+          <SepoliaInstructions />
           <div className="w-full border-t border-info/5" />
-          <div className="flex flex-col justify-center items-center gap-5">
-            <Tag type="success" content="Create a Massa Wallet" />
-            <p className="text-center mas-menu-default w-56">
-              {Intl.t('connect-wallet.ressource-sidepanel.add-massa')}
-            </p>
-            <a
-              className="mas-menu-underline"
-              href={MASSA_STATION_URL}
-              target="_blank"
-            >
-              {Intl.t('general.click-here')}
-            </a>
-          </div>
+          <MassaStationDownload />
         </>
       ) : isOnlyMetamaskConnected && accounts ? (
         <MassaStationInstructions />

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -128,6 +128,8 @@
     "no-wallet": "No wallet is associated with your Massa Account. Please create one and try again!"
   },
   "connect-wallet": {
+    "download-massa": "Download Massa Wallet",
+    "create-wallet": "Create a Massa Wallet",
     "title": "Connect wallets",
     "connected": "Connected wallets",
     "description": "Connect your wallets to start bridging tokens. One EVM wallet and one Massa wallet are required.",
@@ -152,7 +154,7 @@
       "install-metamask": "Install Metamask"
     },
     "station-connect-error": {
-      "error-station": "Unable to detect Massa Station and Massa Wallet. Run the app or download it on the right.",
+      "error-station": "Unable to detect Massa Station and Massa Wallet. Run the app or download it.",
       "error-wallet": "Create a wallet at the  ",
       "add-wallet": "following link.",
       "error-account": "No wallet accounts found in Massa Wallet. ",

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -5,7 +5,7 @@ export const tagTypes = {
   info: 'info',
 };
 
-export const linkToInstall = 'https://station.massa.net/';
+export const MASSA_STATION_INSTALL = 'https://station.massa.net/';
 export const MASSA_STATION_URL = 'https://station.massa';
 export const linkToCreateAccount =
   'https://station.massa/plugin/massa-labs/massa-wallet/web-app/index';


### PR DESCRIPTION

![image](https://github.com/massalabs/bridge-web/assets/126461030/731b180e-0885-4583-a7f7-60fd14aa77fb)

We were showing `create wallet` link for user with no wallet yet. We should propose the download link first.

This MR fixes that.