### PR TITLE
increase fees

### DIFF
--- a/src/const/const.ts
+++ b/src/const/const.ts
@@ -53,12 +53,12 @@ export const AVAILABLE_MODES = [BridgeMode.mainnet, BridgeMode.testnet];
 
 // Transaction fees
 export const forwardBurnFees = {
-  fee: 0n,
+  fee: 10_000_000n,
   coins: 0n,
 };
 
 export const increaseAllowanceFee = {
-  fee: 0n,
+  fee: 10_000_000n,
 };
 
 export enum SupportedTokens {


### PR DESCRIPTION
QA:
- see that for a redeem with a massa account that needs to approve the token contract, you have 0.035 fees in total and 0.015 storage fees (in the tooltip, could be 0.016 if your address has 53 characters)
- see that for a redeem with an massa account that don't needs to approve the token contract, you have an estimation of 0.01 and 0 storage cost
- see that for a bridge operation, you have 0 MAS as estimation