### PR TITLE
fix: empty claim page when switch network

### DIFF
--- a/src/utils/lambdaApi.ts
+++ b/src/utils/lambdaApi.ts
@@ -62,7 +62,7 @@ export const lambdaEndpoint = 'bridge-getHistory-prod';
 
 export function useClaimableOperations() {
   const { address: evmAddress } = useAccount();
-  const { currentMode } = useBridgeModeStore.getState();
+  const { currentMode } = useBridgeModeStore();
 
   const state = BridgingState.processing;
   const queryParams = `?evmAddress=${evmAddress}&entities=${Entities.Burn}&state=${state}`;
@@ -75,14 +75,17 @@ export function useClaimableOperations() {
     useResource<OperationHistoryItem[]>(lambdaUrl);
 
   useEffect(() => {
-    if (!burnOperations?.length) return;
+    if (!burnOperations?.length) {
+      setClaimableOperations([]);
+      return;
+    }
 
     setClaimableOperations(
       burnOperations
         .filter((op) => !op.outputId) // keep only the ones that are not claimed
         .map((opToClaim) => burnOpApiToDTO(opToClaim)),
     );
-  }, [burnOperations]);
+  }, [burnOperations, setClaimableOperations]);
 
   return {
     claimableOperations,


### PR DESCRIPTION
# Bug
- refresh the page, you are in mainnet mode
- go to claim page
- see nothing
- switch to testnet mode
- problem: nothing change, you don't see your transaction (redeem first)

# Fix
- when you switch to testnet mode, your claim transaction appear
- when you switch mode, if you have no transaction or if the server don't answer correctly, it will empty the claim page